### PR TITLE
Expose results export tools and enrich item bank

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -461,6 +461,31 @@ body {
     font-weight: bold;
 }
 
+.result-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 16px 0 4px 0;
+}
+
+.tool-button, .tool-upload {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 0.95em;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+}
+
+.tool-button:hover, .tool-upload:hover {
+  background: #f8fafc;
+}
+
+.tool-upload input[type="file"] {
+  display: none;
+}
+
 .print-button {
     padding: 14px 28px;
     background: white;

--- a/index.html
+++ b/index.html
@@ -50,6 +50,17 @@
                 <div class="results-section">
                     <h2>Your Results 🎉</h2>
                     <div id="resultsContent"></div>
+                    <div class="result-tools">
+                      <button class="tool-button" onclick="generateParentBrief()">Parent summary</button>
+                      <button class="tool-button" onclick="downloadJSON()">Export JSON</button>
+                      <button class="tool-button" onclick="downloadCSV()">Export CSV</button>
+                      <button class="tool-button" onclick="downloadItemBank()">Download item bank</button>
+
+                      <label class="tool-upload">
+                        <input type="file" id="importFile" accept="application/json" onchange="importJSON(this.files[0])">
+                        Import JSON
+                      </label>
+                    </div>
                     <button class="print-button" onclick="printResults()">Print/Save Results</button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add toolbar to results page for parent brief, JSON/CSV exports, item bank download, and JSON import
- Enrich item bank export with scales, score maps, and scoring rules; remove unused slang helper in results
- Show "CORE session" badge when no optional modules are completed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c3ac249e0832583516e736fed6ddc