### PR TITLE
style: improve header readability

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -64,7 +64,7 @@ body {
 .header p {
     font-size: 1.1em;
     opacity: 0.95;
-    color: var(--muted);
+    color: #fff;
 }
 
 .reset-button {
@@ -72,7 +72,7 @@ body {
     top: 20px;
     right: 20px;
     background: transparent;
-    color: var(--muted);
+    color: #fff;
     border: 1px solid var(--border);
     padding: 8px 16px;
     border-radius: 8px;
@@ -82,7 +82,7 @@ body {
 }
 
 .reset-button:hover {
-    color: var(--text);
+    color: #fff;
     border-color: var(--accent);
 }
 
@@ -560,7 +560,7 @@ body {
 
     .header {
         background: none;
-        color: #333;
+        color: #000;
         border-bottom: 2px solid var(--accent);
     }
 
@@ -569,7 +569,7 @@ body {
     }
 
     .header p {
-        color: #666;
+        color: #000;
     }
 
     .reset-button,


### PR DESCRIPTION
## Summary
- set header tagline and Reset Test button text to white for better contrast
- remove gray text from print styles for clear outputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c48c2de6c8325a34491eaaf987bf8