### PR TITLE
Remove accent theme switcher

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,8 +1,8 @@
 :root {
-  --accent: #7c3aed;
-  --accent-600: #5b21b6;
-  --accent-100: #ede9fe;
-  --accent-light: #a855f7;
+  --accent: #6366f1;
+  --accent-600: #4f46e5;
+  --accent-100: #eef2ff;
+  --accent-light: #818cf8;
   --text: #0f172a;
   --text-secondary: #475569;
   --muted: #64748b;
@@ -183,42 +183,7 @@ body::after {
 .header-actions {
   display: inline-flex;
   align-items: center;
-  gap: 16px;
   flex-wrap: wrap;
-}
-
-.accent-swatches {
-  display: inline-flex;
-  gap: 12px;
-  padding: 6px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(255, 255, 255, 0.7);
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
-}
-
-.swatch {
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.8);
-  cursor: pointer;
-  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.18);
-}
-
-.swatch[data-theme="indigo"] { background: #6366f1; }
-.swatch[data-theme="teal"] { background: #14b8a6; }
-.swatch[data-theme="amber"] { background: #f59e0b; }
-
-.swatch:hover {
-  transform: translateY(-3px) scale(1.08);
-  border-color: rgba(255, 255, 255, 1);
-}
-
-.swatch.active {
-  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.55), 0 10px 22px rgba(15, 23, 42, 0.24);
-  transform: translateY(-2px) scale(1.1);
 }
 
 .reset-button {
@@ -911,7 +876,6 @@ body::after {
     background: white;
   }
 
-  .accent-swatches,
   .reset-button,
   .progress-card,
   .navigation,

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,25 +25,6 @@ if (localStorage.getItem('explorerSubsectionIndex')) {
     currentSubsectionIndex = parseInt(localStorage.getItem('explorerSubsectionIndex'));
 }
 
-const THEMES = {
-  indigo:{accent:'#6366f1',accent600:'#4f46e5',accent100:'#eef2ff'},
-  teal:{accent:'#14b8a6',accent600:'#0d9488',accent100:'#ccfbf1'},
-  amber:{accent:'#f59e0b',accent600:'#d97706',accent100:'#fef3c7'}
-};
-
-function setTheme(name){
-  const t = THEMES[name] || THEMES.indigo;
-  Object.entries(t).forEach(([k,v])=>document.documentElement.style.setProperty(`--${k}`, v));
-  localStorage.setItem('explorerTheme', name);
-  document.querySelectorAll('.swatch').forEach(b=>b.classList.toggle('active', b.dataset.theme===name));
-}
-
-(function initTheme(){
-  const saved = localStorage.getItem('explorerTheme') || 'indigo';
-  setTheme(saved);
-  document.querySelectorAll('.swatch').forEach(b=>b.addEventListener('click', ()=>setTheme(b.dataset.theme)));
-})();
-
 // Show resume button if there's saved progress
 document.addEventListener('DOMContentLoaded', () => {
     const hasProgress = Object.keys(responses).length > 0 || currentSection > 0 || selectedModules.length > 0;

--- a/index.html
+++ b/index.html
@@ -25,11 +25,6 @@
                     </div>
                 </div>
                 <div class="header-actions">
-                    <div class="accent-swatches" aria-label="Choose accent theme">
-                        <button class="swatch" data-theme="indigo" title="Indigo"></button>
-                        <button class="swatch" data-theme="teal" title="Teal"></button>
-                        <button class="swatch" data-theme="amber" title="Amber"></button>
-                    </div>
                     <button class="reset-button" onclick="resetTest()">Reset everything</button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- remove the accent swatch controls from the header, leaving only the reset button
- drop the runtime theme switching code and rely on static CSS variables for the default palette
- clean up stylesheet rules that only supported the accent picker

## Testing
- Playwright smoke test (no console errors)

------
https://chatgpt.com/codex/tasks/task_e_68e69f62b42483258fdead677686d1aa